### PR TITLE
Fix URL unwrap fatal error in xcode preview

### DIFF
--- a/Light-Swift-Untar.swift
+++ b/Light-Swift-Untar.swift
@@ -35,7 +35,7 @@ public extension FileManager {
       switch type {
       case "0": // File
         let name = self.name(object: tarObject, offset: location)
-        let filePath = URL(string: path)!.appendingPathComponent(name).path
+        let filePath = URL(fileURLWithPath: path).appendingPathComponent(name).path
         let size = self.size(object: tarObject, offset: location)
         if size == 0 { try "".write(toFile: filePath, atomically: true, encoding: .utf8) }
         else {
@@ -45,7 +45,7 @@ public extension FileManager {
         }
       case "5": // Directory
         let name = self.name(object: tarObject, offset: location)
-        let directoryPath = URL(string: path)!.appendingPathComponent(name).path
+        let directoryPath = URL(fileURLWithPath: path).appendingPathComponent(name).path
         try createDirectory(atPath: directoryPath, withIntermediateDirectories: true,
                             attributes: nil)
       case "\0": break // Null block


### PR DESCRIPTION
Updated FileManager extension to use init(fileURLWithPath:)
URL initializer when constructing file path in switch statement
for 'file' and 'directory' types.

Xcode preview was crashing due to the URL force unwrap encountering
a nil value. This happens when the path contains a space and hence
URL(string:) returns a nil value.
The root cause; "Simulator Devices" folder located in:
/Users/<username>/Library/Developer/Xcode/UserData/Previews

On my device i actuall have a directory with a space and a directory
with a URL encoded space;
./Simulator Devices
./Simulator%20Devices

Making the above change prevents the fatal error and still seems to use
the correct directory (Simulator Devices).
I imagine this is really an apple/xcode issue and there should only
be one of those directories present.

Tested on Simulator and physical device; working as expected.